### PR TITLE
Various improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+venv
+*.json-dist
+*.iml
+.idea

--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
 # SdPaint
 A simple python script that lets you paint on a canvas and sends that image every stroke to the automatic1111 API and updates the canvas when the image is generated
 
-## Updates
+## Controls
 
-- added the possibility to save the image created by pressing the ```s``` key
-- You can use the scrollmouse key to change the brush size
+| Key / Mouse button                  | Control                          |
+|-------------------------------------|----------------------------------|
+| Left button                         | Draw with the current brush size |
+| Scroll up / down                    | Increase / decrease brush size   |
+| Middle button, or `e` + Left button | Eraser                           |
+| `shift` + Left button               | Draw a line                      |
+| `s`                                 | Save the current generated image |
+| `RETURN` or `ENTER`                 | Force image rendering            |
+| `UP` / `DOWN`                       | Increase / decrease seed by 1    |
+| `n`                                 | Random seed value                |
+| `x` or `ESC`                        | Quit                             |
+
 
 ## Installation
 

--- a/Scripts/SdPaint.py
+++ b/Scripts/SdPaint.py
@@ -6,36 +6,78 @@ import base64
 import io
 import json
 import time
+import math
 from PIL import Image, ImageOps
 import tkinter as tk
 from tkinter import filedialog
 
 # Initialize Pygame
 pygame.init()
+clock = pygame.time.Clock()
 
 # setup sd inputs
 url = "http://127.0.0.1:7860"
 prompt = "A painting by Monet"
 seed = 3456456767
 
+
+def update_size():
+    global width, height, soft_upscale
+
+    interface_width = settings.get('interface_width', width * 2)
+    interface_height = settings.get('interface_height', height)
+
+    if round(interface_width / interface_height * 100) != round(width * 2 / height * 100):
+        ratio = width / height
+        print(f"different ratios{interface_width / interface_height} != {width * 2 / height}")
+        if ratio < 1:
+            interface_width = math.floor(interface_height * ratio)
+        else:
+            interface_height = math.floor(interface_width * ratio)
+
+    soft_upscale = 1.0
+    if interface_width != width * 2 or interface_height != height:
+        soft_upscale = min(settings['interface_width'] / width, settings['interface_height'] / height)
+
+    if settings['enable_hr'] == 'true':
+        soft_upscale = soft_upscale / settings['hr_scale']
+        width = math.floor(width * settings['hr_scale'])
+        height = math.floor(height * settings['hr_scale'])
+
+    width = math.floor(width * soft_upscale)
+    height = math.floor(height * soft_upscale)
+
+
+# read settings from payload
+with open("payload.json", "r") as f:
+    settings = json.load(f)
+    width = settings.get('width', 512)
+    height = settings.get('height', 512)
+    soft_upscale = 1.0
+    update_size()
+
 # Set up the display
-screen = pygame.display.set_mode((1024, 512))
+fullscreen = False
+screen = pygame.display.set_mode((width*2, height))
 pygame.display.set_caption("Sd Paint")
 
 # Setup text
 font = pygame.font.SysFont(None, 24)
 text_input = ""
 # Set up the drawing surface
-canvas = pygame.Surface((1024, 512))
-pygame.draw.rect(canvas, (255, 255, 255), (0, 0, 1024, 512))
+canvas = pygame.Surface((width*2, height))
+pygame.draw.rect(canvas, (255, 255, 255), (0, 0, width*2, height))
 
 # Set up the brush
-brush_size = {1: 2, 2: 10}
+brush_size = {1: 2, 2: 10, 'e': 10}
 brush_colors = {
     1: (0, 0, 0),  # Left mouse button color
     2: (255, 255, 255),  # Middle mouse button color
+    'e': (255, 255, 255),  # Eraser color
 }
-brush_pos = {1: None, 2: None}
+brush_pos = {1: None, 2: None, 'e': None}
+prev_brush_pos = {1: None, 2: None, 'e': None}
+eraser_down = False
 
 # Define the cursor size and color
 cursor_size = 1
@@ -58,36 +100,70 @@ def update_image(image_data):
     # Decode base64 image data
     img_bytes = io.BytesIO(base64.b64decode(image_data))
     img_surface = pygame.image.load(img_bytes)
+    if soft_upscale != 1.0:
+        img_surface = pygame.transform.smoothscale(img_surface, (img_surface.get_width() * soft_upscale, img_surface.get_height() * soft_upscale))
+
     canvas.blit(img_surface, (0, 0))
+    global need_redraw
+    need_redraw = True
 
 # Set up the main loop
 running = True
+need_redraw = True
 while running:
-
     # Handle events
     for event in pygame.event.get():
+        need_redraw = True
+
         if event.type == pygame.QUIT:
             running = False
-        elif event.type == pygame.KEYDOWN:
+        elif event.type == pygame.KEYDOWN and event.key not in (pygame.K_RETURN, pygame.K_KP_ENTER):
             if event.key == pygame.K_BACKSPACE:
-                pygame.draw.rect(canvas, (255, 255, 255), (512, 0, 512, 512))
+                pygame.draw.rect(canvas, (255, 255, 255), (width, 0, width, height))
             elif event.key == pygame.K_s:
                 save_file_dialog()
+            elif event.key == pygame.K_e:
+                eraser_down = True
+            elif event.key == pygame.K_f:
+                fullscreen = not fullscreen
+                if fullscreen:
+                    screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
+                else:
+                    screen = pygame.display.set_mode((width*2, height))
+            elif event.key in (pygame.K_ESCAPE, pygame.K_x):
+                pygame.quit()
+                exit(0)
+        elif event.type == pygame.KEYUP:
+            if event.key == pygame.K_e:
+                eraser_down = False
+                brush_pos['e'] = None
         elif event.type == pygame.MOUSEBUTTONDOWN:
-            if event.button in brush_colors:
-                brush_pos[event.button] = event.pos
+            brush_key = event.button
+            if eraser_down:
+                brush_key = 'e'
+
+            if brush_key in brush_colors:
+                prev_brush_pos[brush_key] = brush_pos.get(brush_key, None)
+                brush_pos[brush_key] = event.pos
             elif event.button == 4:  # scroll up
                 brush_size[1] = max(1, brush_size[1] + 1)
             elif event.button == 5:  # scroll down
                 brush_size[1] = max(1, brush_size[1] - 1)
-        elif event.type == pygame.MOUSEBUTTONUP:
-            if event.button in brush_colors:
-                brush_pos[event.button] = None
-                brush_color = brush_colors[event.button]
+        elif event.type == pygame.MOUSEBUTTONUP or (event.type == pygame.KEYDOWN and event.key in (pygame.K_RETURN, pygame.K_KP_ENTER)):
+            if event.type == pygame.KEYDOWN:
+                event.button = 1
+
+            if event.button in brush_colors or eraser_down:
+                brush_key = event.button
+                if eraser_down:
+                    brush_key = 'e'
+
+                brush_pos[brush_key] = None
+                brush_color = brush_colors[brush_key]
                 # Check if server is busy before sending request
                 if not server_busy:
                     server_busy = True
-                    img = canvas.subsurface(pygame.Rect(512, 0, 512, 512)).copy()
+                    img = canvas.subsurface(pygame.Rect(width, 0, width, height)).copy()
 
                     # Convert the Pygame surface to a PIL image
                     pil_img = Image.frombytes('RGB', img.get_size(), pygame.image.tostring(img, 'RGB'))
@@ -105,25 +181,40 @@ while running:
                     with open("payload.json", "r") as f:
                         payload = json.load(f)
                     payload['controlnet_units'][0]['input_image'] = data
-                    
+                    payload['hr_second_pass_steps'] = math.floor(payload['steps'] * payload['denoising_strength'])
+
                     def send_request():
                         global server_busy
                         response = requests.post(url=f'{url}/controlnet/txt2img', json=payload)
-                        r = response.json()
-                        return_img = r['images'][0]
-                        update_image(return_img)
+                        if response.status_code == 200:
+                            r = response.json()
+                            return_img = r['images'][0]
+                            update_image(return_img)
+                        else:
+                            print(f"Error code returned: HTTP {response.status_code}")
+
                         server_busy = False
-                    
+
                     t = threading.Thread(target=send_request)
                     t.start()
+
         elif event.type == pygame.MOUSEMOTION:
             for button, pos in brush_pos.items():
                 if pos is not None and button in brush_colors:
-                    pygame.draw.circle(canvas, brush_colors[button], event.pos, brush_size[button])
-    
+                    prev_pos = prev_brush_pos.get(button, None)
+                    if prev_pos is None:
+                        pygame.draw.circle(canvas, brush_colors[button], event.pos, brush_size[button])
+                    else:
+                        pygame.draw.line(canvas, brush_colors[button], prev_pos, event.pos, brush_size[button])
+
+                    prev_brush_pos[button] = event.pos
+
+        else:
+            need_redraw = False
+
     # Draw the canvas and brushes on the screen
     screen.blit(canvas, (0, 0))
-    
+
     # Create a new surface with a circle
     cursor_size = brush_size[1]*2
     cursor_surface = pygame.Surface((cursor_size, cursor_size), pygame.SRCALPHA)
@@ -132,13 +223,18 @@ while running:
     # Blit the cursor surface onto the screen surface at the position of the mouse
     mouse_pos = pygame.mouse.get_pos()
     screen.blit(cursor_surface, (mouse_pos[0] - cursor_size // 2, mouse_pos[1] - cursor_size // 2))
-        
-    for button, pos in brush_pos.items():
-        if pos is not None and button in brush_colors:
-            pygame.draw.circle(screen, brush_colors[button], pos, brush_size[button])
+
+    # for button, pos in brush_pos.items():
+    #     if pos is not None and button in brush_colors:
+    #         pygame.draw.circle(screen, brush_colors[button], pos, brush_size[button])
 
     # Update the display
-    pygame.display.update()
+    if need_redraw:
+        pygame.display.flip()
+        need_redraw = False
+
+    # Set max FPS
+    clock.tick(240)
 
 # Clean up Pygame
 pygame.quit()

--- a/payload.json
+++ b/payload.json
@@ -1,19 +1,26 @@
 {
-    "enable_hr": "false",
-    "prompt": "A painting in the style of Monet",
-    "seed": 3456789904,
-    "sampler_name": "Euler a",
+    "interface_width": 1920,
+    "interface_height": 1080,
+    "enable_hr": "true",
+    "denoising_strength": 0.6,
+    "hr_upscaler": "Latent (bicubic)",
+    "hr_scale": 1.25,
+    "prompt": "a castle on a giant whale",
+    "seed": 42,
+    "sampler_name": "UniPC",
     "batch_size": 1,
-    "steps": 15,
+    "steps": 16,
     "cfg_scale": 7,
-    "width": 512,
-    "height": 512,
-    "negative_prompt": "",
+    "width": 640,
+    "height": 720,
+    "negative_prompt": "easynegative,(worst quality,low quality,bad quality,normal quality:1.2)",
     "controlnet_units": [
         {
-            "weight": 1.0,
+            "weight": 0.6,
+            "guidance_start": 0.0,
+            "guidance_end": 1.0,
             "module": "none",
-            "model": "control_sd15_scribble [fef5e48e]",
+            "model": "control_v11p_sd15_scribble_fp16",
             "guessmode": "false"
         }
     ]


### PR DESCRIPTION
Added multiple features and improvements : 

 - Support for touch controls (stylus & tablets)
 - Draw lines instead of dots
 - Read parameters and settings from `payload.json`
 - Interface width & height settings
   - local upscale of rendered image if needed
   - save rendered image in its native resolution
 - Support for hrfix rendering
   - Calculate hr steps according to denoising value
 - Cap framerate to 120fps, update drawing only when necessary
 - Handle HTTP error codes
 - Default `.gitignore` to ignore Python virtual env & IDE directories
 - Updated README with controls

Added key controls for :  
 - `e` + left click to use eraser (useful for stylus controls)
 - `shift` + left click to draw straight lines
 - `x` or `esc` to exit
 - `f` for fullscreen (without canvas resizing for now, but useful if the interface dimension is your screen size, ie. on a drawing board)
 - `up`, `down`, `n` for seed control : increase, decrease, new
 - `enter` to force rendering