### PR TITLE
Add CLIP skip shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A Python script that lets you paint on a canvas and sends that image every strok
 | `d`                   | Cycle ControlNet detectors, replace sketch  |
 | `h`                   | Cycle HR fix: off, 1.25, 1.5, 2.0           |
 | `q`                   | Toggle quick rendering : low steps & HR off |
+| `c`                   | Cycle CLIP skip settings                    |
 | `x` or `ESC`          | Quit                                        |
 
 

--- a/controlnet-high.json-dist
+++ b/controlnet-high.json-dist
@@ -12,7 +12,11 @@
     "quick_steps": 12,
     "cfg_scale": 7,
     "width": 640,
-    "height": 720,
+    "height": 720,,
+    "override_settings": {
+        "CLIP_stop_at_last_layers": 1
+    },
+    "override_settings_restore_afterwards": "true"
     "controlnet_units": [
         {
             "weight": 0.6,

--- a/controlnet-high.json-dist
+++ b/controlnet-high.json-dist
@@ -12,7 +12,7 @@
     "quick_steps": 12,
     "cfg_scale": 7,
     "width": 640,
-    "height": 720,,
+    "height": 720,
     "override_settings": {
         "CLIP_stop_at_last_layers": 1
     },

--- a/controlnet.json-dist
+++ b/controlnet.json-dist
@@ -12,7 +12,11 @@
     "quick_steps": 12,
     "cfg_scale": 7,
     "width": 512,
-    "height": 512,
+    "height": 512,,
+    "override_settings": {
+        "CLIP_stop_at_last_layers": 1
+    },
+    "override_settings_restore_afterwards": "true"
     "controlnet_units": [
         {
             "weight": 0.6,

--- a/controlnet.json-dist
+++ b/controlnet.json-dist
@@ -12,7 +12,7 @@
     "quick_steps": 12,
     "cfg_scale": 7,
     "width": 512,
-    "height": 512,,
+    "height": 512,
     "override_settings": {
         "CLIP_stop_at_last_layers": 1
     },

--- a/img2img.json-dist
+++ b/img2img.json-dist
@@ -7,5 +7,9 @@
     "batch_size": 1,
     "steps": 16,
     "quick_steps": 12,
-    "cfg_scale": 7
+    "cfg_scale": 7,
+	"override_settings": {
+		"CLIP_stop_at_last_layers": 1
+	},
+	"override_settings_restore_afterwards": "true"
 }


### PR DESCRIPTION
Added `c` keyboard shortcut to CLIP skip settings. Modified payload files to include the setting at 1 by default.