### PR TITLE
Typo in controlnet configuration files

### DIFF
--- a/controlnet-high.json-dist
+++ b/controlnet-high.json-dist
@@ -16,7 +16,7 @@
     "override_settings": {
         "CLIP_stop_at_last_layers": 1
     },
-    "override_settings_restore_afterwards": "true"
+    "override_settings_restore_afterwards": "true",
     "controlnet_units": [
         {
             "weight": 0.6,

--- a/controlnet.json-dist
+++ b/controlnet.json-dist
@@ -16,7 +16,7 @@
     "override_settings": {
         "CLIP_stop_at_last_layers": 1
     },
-    "override_settings_restore_afterwards": "true"
+    "override_settings_restore_afterwards": "true",
     "controlnet_units": [
         {
             "weight": 0.6,


### PR DESCRIPTION
Corrected a missing `,` in the distribution configuration files.