### PR TITLE
LCM LoRA quick mode handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,49 +5,49 @@ the canvas when the image is generated.
 
 ## Controls
 
-| Key / Mouse button            | Control                                         |
-| ----------------------------- | ----------------------------------------------- |
-| Left button                   | Draw with the current brush size                |
-| Middle button                 | Draw with a white color brush                   |
-| `e` + Left button             | Eraser brush (bigger)                           |
-| Scroll up / down              | Increase / decrease brush size                  |
-| `1` to `9`                    | Set brush size                                  |
-| `backspace`                   | Erase the entire sketch                         |
-| `shift` + Left button         | Draw a line between two clicks                  |
-| `RETURN` or `ENTER`           | Request image rendering                         |
-| `ctrl` + `i`                  | Interrupt image rendering                       |
-| `c`                           | Display current configuration while pressed     |
-| `p`                           | Edit prompt                                     |
-| `alt` + `p`                   | Edit negative prompt                            |
-| `a`                           | Toggle autosave                                 |
-| `shift` + `t`                 | Cycle render wait time (+0.5s, or off)          |
-| `ctrl` + `p`                  | Pause dynamic rendering                         |
-| `q`                           | Toggle quick rendering : low steps & HR fix off |
-| `n`                           | Random seed value                               |
-| `ctrl` + `n`                  | Edit seed value                                 |
-| `UP` / `DOWN`                 | Increase / decrease seed by 1                   |
-| `ctrl`+ `s`                   | Save the current generated image                |
-| `ctrl`+ `o`                   | Open an image file as sketch                    |
-| `ctrl`+ `d`                   | Call ControlNet detector (replace sketch)       |
-| `shift` + `ctrl`+ `d`         | Cycle ControlNet detectors                      |
-| `h`                           | Toggle HR fix                                   |
-| `shift` + `h`                 | Cycle HR fix scale                              |
-| `shift` + `u`                 | Cycle HR upscalers                              |
-| `shift` + `d`                 | Cycle denoising strengths                       |
-| `shift` + `s`                 | Cycle samplers                                  |
-| `b`                           | Toggle batch rendering                          |
-| `shift` + `b`                 | Cycle batch sizes                               |
-| `shift` + `c`                 | Cycle CLIP skip settings                        |
-| `shift` + `m`                 | Cycle ControlNel models                         |
-| `shift` + `w`                 | Cycle ControlNel weights                        |
-| `shift` + `g`                 | Cycle ControlNel guidance ends                  |
-| `shift` + `ctrl` + `g`        | Toggle ControlNel pixel perfect mode            |
-| `keypad 0`                    | Restore starting settings                       |
-| `keypad 1-9`                  | Load custom rendering preset                    |
-| `ctrl` + `keypad 1-9`         | Save custom rendering preset                    |
-| `alt` + `keypad 1-9`          | Load custom ControlNet preset                   |
-| `ctrl` + `alt` + `keypad 1-9` | Save custom ControlNet preset                   |
-| `x` or `ESC`                  | Quit                                            |
+| Key / Mouse button            | Control                                            |
+| ----------------------------- |----------------------------------------------------|
+| Left button                   | Draw with the current brush size                   |
+| Middle button                 | Draw with a white color brush                      |
+| `e` + Left button             | Eraser brush (bigger)                              |
+| Scroll up / down              | Increase / decrease brush size                     |
+| `1` to `9`                    | Set brush size                                     |
+| `backspace`                   | Erase the entire sketch                            |
+| `shift` + Left button         | Draw a line between two clicks                     |
+| `RETURN` or `ENTER`           | Request image rendering                            |
+| `ctrl` + `i`                  | Interrupt image rendering                          |
+| `c`                           | Display current configuration while pressed        |
+| `p`                           | Edit prompt                                        |
+| `alt` + `p`                   | Edit negative prompt                               |
+| `a`                           | Toggle autosave                                    |
+| `shift` + `t`                 | Cycle render wait time (+0.5s, or off)             |
+| `ctrl` + `p`                  | Pause dynamic rendering                            |
+| `q`                           | Toggle quick rendering, with LCM LoRA if available |
+| `n`                           | Random seed value                                  |
+| `ctrl` + `n`                  | Edit seed value                                    |
+| `UP` / `DOWN`                 | Increase / decrease seed by 1                      |
+| `ctrl`+ `s`                   | Save the current generated image                   |
+| `ctrl`+ `o`                   | Open an image file as sketch                       |
+| `ctrl`+ `d`                   | Call ControlNet detector (replace sketch)          |
+| `shift` + `ctrl`+ `d`         | Cycle ControlNet detectors                         |
+| `h`                           | Toggle HR fix                                      |
+| `shift` + `h`                 | Cycle HR fix scale                                 |
+| `shift` + `u`                 | Cycle HR upscalers                                 |
+| `shift` + `d`                 | Cycle denoising strengths                          |
+| `shift` + `s`                 | Cycle samplers                                     |
+| `b`                           | Toggle batch rendering                             |
+| `shift` + `b`                 | Cycle batch sizes                                  |
+| `shift` + `c`                 | Cycle CLIP skip settings                           |
+| `shift` + `m`                 | Cycle ControlNel models                            |
+| `shift` + `w`                 | Cycle ControlNel weights                           |
+| `shift` + `g`                 | Cycle ControlNel guidance ends                     |
+| `shift` + `ctrl` + `g`        | Toggle ControlNel pixel perfect mode               |
+| `keypad 0`                    | Restore starting settings                          |
+| `keypad 1-9`                  | Load custom rendering preset                       |
+| `ctrl` + `keypad 1-9`         | Save custom rendering preset                       |
+| `alt` + `keypad 1-9`          | Load custom ControlNet preset                      |
+| `ctrl` + `alt` + `keypad 1-9` | Save custom ControlNet preset                      |
+| `x` or `ESC`                  | Quit                                               |
 
 _Note_ : "Cycle" shortcuts type will wait for the `shift` key to be released before launching the rendering.
 
@@ -94,6 +94,18 @@ models folder of the controlnet extension.
 ```
     ".\stable-diffusion-webui\extensions\sd-webui-controlnet\models"
 ```
+
+### Quick mode / LCM LoRA
+
+The quick mode is able to use a very low number of steps with [Latent Consistency Models LoRAs](https://huggingface.co/blog/lcm_lora) .
+To be able to use it fully, please download the LCM LoRAs for SD 1.5 and/or SDXL on huggingface :
+- [LCM LoRA for SD 1.5](https://huggingface.co/latent-consistency/lcm-lora-sdv1-5)
+- [LCM LoRA for SDXL](https://huggingface.co/latent-consistency/lcm-lora-sdxl)
+
+Save the safetensors files as `LCM_LoRA_Weights.safetensors` in the `./models/LoRA/` directory of your Stable Diffusion WebUI installation.
+The name of the LoRA is configurable in the JSON configuration files `controlnet.json` and `img2img.json` with the `quick.lora` entry.
+You can also configure the steps, cfg scale, sampler, and LoRA weight used. The default quick setting gives a good quality/performance ratio
+with DPM++ SDE Karras and 6 steps. HRFix is disabled when first entering quick mode, but you can activate it if wanted by pressing the `h` key.
 
 ### Autosave
 

--- a/configs/controlnet-high.json-dist
+++ b/configs/controlnet-high.json-dist
@@ -5,8 +5,14 @@
     "seed": 42,
     "batch_size": 1,
     "steps": 16,
-    "quick_steps": 12,
     "cfg_scale": 7,
+    "quick": {
+        "steps": 6,
+        "cfg_scale": 3,
+        "lora":  "LCM_LoRA_Weights",
+        "lora_weight": 0.4,
+        "sampler": "DPM++ SDE Karras"
+    },
     "width": 640,
     "height": 720,
     "override_settings": {

--- a/configs/controlnet.json-dist
+++ b/configs/controlnet.json-dist
@@ -5,8 +5,14 @@
     "seed": 42,
     "batch_size": 1,
     "steps": 16,
-    "quick_steps": 12,
     "cfg_scale": 7,
+    "quick": {
+        "steps": 6,
+        "cfg_scale": 3,
+        "lora":  "LCM_LoRA_Weights",
+        "lora_weight": 0.4,
+        "sampler": "DPM++ SDE Karras"
+    },
     "width": 512,
     "height": 512,
     "override_settings": {

--- a/configs/img2img.json-dist
+++ b/configs/img2img.json-dist
@@ -4,8 +4,14 @@
     "seed": 42,
     "batch_size": 1,
     "steps": 16,
-    "quick_steps": 12,
     "cfg_scale": 7,
+    "quick": {
+        "steps": 6,
+        "cfg_scale": 3,
+        "lora":  "LCM_LoRA_Weights",
+        "lora_weight": 0.4,
+        "sampler": "DPM++ SDE Karras"
+    },
     "override_settings": {
         "CLIP_stop_at_last_layers": 1
     },

--- a/scripts/common/state.py
+++ b/scripts/common/state.py
@@ -26,6 +26,8 @@ class State:
     render = {
         "checkpoint": None,
         "vae": None,
+        "steps": 16,
+        "cfg_scale": 7,
         "hr_scales": [],
         "hr_scale": 1.0,
         "hr_scale_prev": 1.25,
@@ -45,6 +47,7 @@ class State:
         "use_invert_module": True,
         "quick_mode": False,
         "clip_skip_setting": 'clip_skip',
+        "quick": {}
     }
     control_net = {
         "config_file": "configs/controlnet.json",
@@ -162,6 +165,9 @@ class State:
             hr_scales.insert(0, 1.0)
         hr_scale = hr_scales[0]
 
+        self.render['steps'] = self.configuration["config"].get("steps", 16)
+        self.render['cfg_scale'] = self.configuration["config"].get("cfg_scale", 7)
+        self.render['quick'] = self.configuration["config"].get("quick", {})
         self.render["hr_scale_prev"] = hr_scales[1]
         self.render["denoising_strengths"] = self.configuration["config"].get("denoising_strengths", [0.6])
         self.render["denoising_strength"] = self.render["denoising_strengths"][0]
@@ -218,6 +224,10 @@ class State:
         if settings.get('enable_hr', 'false') == 'true':
             self.render["hr_scale"] = self.render["hr_scales"][1]
             self.render["batch_hr_scale_prev"] = self.render["hr_scale"]
+
+        self.render['steps'] = settings.get("steps", 16)
+        self.render['cfg_scale'] = settings.get("cfg_scale", 7)
+        self.render['quick'] = settings.get("quick", {})
 
         self.gen_settings["prompt"] = settings.get('prompt', '')
         self.gen_settings["negative_prompt"] = settings.get('negative_prompt', '')


### PR DESCRIPTION
Handle LCM LoRA for quick mode to allow very low steps number with a good quality. Switching between quick and normal mode with the `q` key.

The configuration files are updated to handle the new quick mode settings : sampler, steps, cfg scale and LCM LoRA name & weight. 