### PR TITLE
Eraser zone tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ the canvas when the image is generated.
 ## Controls
 
 | Key / Mouse button            | Control                                            |
-| ----------------------------- |----------------------------------------------------|
+|-------------------------------|----------------------------------------------------|
 | Left button                   | Draw with the current brush size                   |
 | Middle button                 | Draw with a white color brush                      |
 | `e` + Left button             | Eraser brush (bigger)                              |
+| `z` + Left button             | Draw zone to be erased                             |
 | Scroll up / down              | Increase / decrease brush size                     |
 | `1` to `9`                    | Set brush size                                     |
 | `backspace`                   | Erase the entire sketch                            |


### PR DESCRIPTION
Added a new shortcut 'z' for eraser zone tool. While the key is pressed, the main click is used to draw a zone in light grey (either by dragging or clicking multiple points). When the key is released, the zone is erased.